### PR TITLE
small readme fix

### DIFF
--- a/Features/dockerform-yocordapp/README.md
+++ b/Features/dockerform-yocordapp/README.md
@@ -37,7 +37,7 @@ We will interact with the nodes via their specific shells. When the nodes are up
 
 ```sh
 # find the ssh port for PartyA using docker ps
-ssh user1@0.0.0.0 -p 2223
+ssh user1@0.0.0.0 -p 2222
 
 # the password defined in the node config for PartyA is "test"
 Password: test
@@ -47,7 +47,7 @@ Welcome to the Corda interactive shell.
 You can see the available commands by typing 'help'.
 
 # you'll see the corda shell available and can run flows
-Fri May 15 18:23:03 GMT 2020>>> flow start YoFlow target: PartyA
+Fri May 15 18:23:03 GMT 2020>>> flow start YoFlow target: PartyB
 
  ✓ Starting
  ✓ Creating a new Yo!

--- a/Features/dockerform-yocordapp/build.gradle
+++ b/Features/dockerform-yocordapp/build.gradle
@@ -90,54 +90,6 @@ cordapp {
     }
 }
 
-
-task deployNodesJava(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
-
-    nodeDefaults {
-        projectCordapp {
-            deploy = false
-        }
-        cordapp project("contracts")
-        cordapp project("workflows")
-        rpcUsers = [[user: "user1", "password": "test", "permissions": ["ALL"]]]
-    }
-
-    node {
-        name "O=Notary,L=London,C=GB"
-        notary = [validating: false]
-        p2pPort 10001
-        p2pAddress "0.0.0.0"
-        rpcSettings {
-            address("0.0.0.0:10011")
-            adminAddress("0.0.0.0:10041")
-        }
-        sshdPort 2221
-    }
-
-    node {
-        name "O=PartyA,L=London,C=GB"
-        p2pPort 10002
-        p2pAddress "0.0.0.0"
-        rpcSettings {
-            address("0.0.0.0:10012")
-            adminAddress("0.0.0.0:10042")
-        }
-        sshdPort 2222
-    }
-
-    node {
-        name "O=PartyB,L=New York,C=US"
-        p2pPort 10003
-        p2pAddress "0.0.0.0"
-        rpcSettings {
-            address("0.0.0.0:10013")
-            adminAddress("0.0.0.0:10043")
-        }
-        sshdPort 2223
-    }
-}
-
-
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) {
 
     dockerImage = "corda/corda-zulu-java1.8-" + corda_release_version + ":latest"


### PR DESCRIPTION
removing the cordform version of the config as it was causing confusion. 

the goal of the sample is the dockerform config so that's what we're keeping here. 
