### PR TITLE
ENT-6871: Clean up & apply formatting to Java tutorial-applestamp

### DIFF
--- a/Basic/tutorial-applestamp/contracts/src/main/java/com/tutorial/contracts/AppleStampContract.java
+++ b/Basic/tutorial-applestamp/contracts/src/main/java/com/tutorial/contracts/AppleStampContract.java
@@ -1,14 +1,12 @@
 package com.tutorial.contracts;
 
 import com.tutorial.states.AppleStamp;
-import com.tutorial.states.BasketOfApples;
 import net.corda.core.contracts.CommandData;
 import net.corda.core.contracts.Contract;
 import net.corda.core.transactions.LedgerTransaction;
 import org.jetbrains.annotations.NotNull;
 
-import static net.corda.core.contracts.ContractsDSL.requireThat; //Domain Specific Language
-
+import static net.corda.core.contracts.ContractsDSL.requireThat;
 
 public class AppleStampContract implements Contract {
 
@@ -22,17 +20,16 @@ public class AppleStampContract implements Contract {
         final CommandData commandData = tx.getCommands().get(0).getValue();
 
         //Verify the transaction according to the intention of the transaction
-        if (commandData instanceof AppleStampContract.Commands.Issue){
+        if (commandData instanceof AppleStampContract.Commands.Issue) {
             AppleStamp output = tx.outputsOfType(AppleStamp.class).get(0);
             requireThat(require -> {
                 require.using("This transaction should only have one AppleStamp state as output", tx.getOutputs().size() == 1);
                 require.using("The output AppleStamp state should have clear description of the type of redeemable goods", !output.getStampDesc().equals(""));
                 return null;
             });
-        }else if(commandData instanceof BasketOfApplesContract.Commands.Redeem){
+        } else if (commandData instanceof BasketOfApplesContract.Commands.Redeem) {
             //Transaction verification will happen in BasketOfApples Contract
-        }
-        else{
+        } else {
             //Unrecognized Command type
             throw new IllegalArgumentException("Incorrect type of AppleStamp Commands");
         }
@@ -41,6 +38,7 @@ public class AppleStampContract implements Contract {
     // Used to indicate the transaction's intent.
     public interface Commands extends CommandData {
         //In our hello-world app, We will have two commands.
-        class Issue implements AppleStampContract.Commands {}
+        class Issue implements AppleStampContract.Commands {
+        }
     }
 }

--- a/Basic/tutorial-applestamp/contracts/src/main/java/com/tutorial/contracts/BasketOfApplesContract.java
+++ b/Basic/tutorial-applestamp/contracts/src/main/java/com/tutorial/contracts/BasketOfApplesContract.java
@@ -14,13 +14,12 @@ public class BasketOfApplesContract implements Contract {
     // This is used to identify our contract when building a transaction.
     public static final String ID = "com.tutorial.contracts.BasketOfApplesContract";
 
-
     @Override
     public void verify(@NotNull LedgerTransaction tx) throws IllegalArgumentException {
         //Extract the command from the transaction.
         final CommandData commandData = tx.getCommands().get(0).getValue();
 
-        if (commandData instanceof BasketOfApplesContract.Commands.packBasket){
+        if (commandData instanceof BasketOfApplesContract.Commands.packBasket) {
             BasketOfApples output = tx.outputsOfType(BasketOfApples.class).get(0);
             requireThat(require -> {
                 require.using("This transaction should only output one BasketOfApples state", tx.getOutputs().size() == 1);
@@ -28,8 +27,7 @@ public class BasketOfApplesContract implements Contract {
                 require.using("The output BasketOfApples state should have non zero weight", output.getWeight() > 0);
                 return null;
             });
-        }
-        else if (commandData instanceof BasketOfApplesContract.Commands.Redeem) {
+        } else if (commandData instanceof BasketOfApplesContract.Commands.Redeem) {
             //Retrieve the output state of the transaction
             AppleStamp input = tx.inputsOfType(AppleStamp.class).get(0);
             BasketOfApples output = tx.outputsOfType(BasketOfApples.class).get(0);
@@ -41,8 +39,7 @@ public class BasketOfApplesContract implements Contract {
                 require.using("The basket of apple has to weight more than 0", output.getWeight() > 0);
                 return null;
             });
-        }
-        else{
+        } else {
             //Unrecognized Command type
             throw new IllegalArgumentException("Incorrect type of BasketOfApples Commands");
         }
@@ -50,8 +47,10 @@ public class BasketOfApplesContract implements Contract {
 
     // Used to indicate the transaction's intent.
     public interface Commands extends CommandData {
-        class packBasket implements BasketOfApplesContract.Commands {}
-        class Redeem implements BasketOfApplesContract.Commands {}
+        class packBasket implements BasketOfApplesContract.Commands {
+        }
 
+        class Redeem implements BasketOfApplesContract.Commands {
+        }
     }
 }

--- a/Basic/tutorial-applestamp/contracts/src/main/java/com/tutorial/contracts/TemplateContract.java
+++ b/Basic/tutorial-applestamp/contracts/src/main/java/com/tutorial/contracts/TemplateContract.java
@@ -40,6 +40,7 @@ public class TemplateContract implements Contract {
     // Used to indicate the transaction's intent.
     public interface Commands extends CommandData {
         //In our hello-world app, We will only have one command.
-        class Send implements Commands {}
+        class Send implements Commands {
+        }
     }
 }

--- a/Basic/tutorial-applestamp/contracts/src/test/java/com/tutorial/contracts/ContractTests.java
+++ b/Basic/tutorial-applestamp/contracts/src/test/java/com/tutorial/contracts/ContractTests.java
@@ -12,16 +12,15 @@ import java.util.Arrays;
 
 import static net.corda.testing.node.NodeTestUtils.ledger;
 
-
 public class ContractTests {
     private final MockServices ledgerServices = new MockServices(Arrays.asList("com.tutorial.contracts"));
-    TestIdentity alice = new TestIdentity(new CordaX500Name("Alice",  "TestLand",  "US"));
-    TestIdentity bob = new TestIdentity(new CordaX500Name("Alice",  "TestLand",  "US"));
+    TestIdentity alice = new TestIdentity(new CordaX500Name("Alice", "TestLand", "US"));
+    TestIdentity bob = new TestIdentity(new CordaX500Name("Alice", "TestLand", "US"));
 
     //Template Tester
     @Test
     public void issuerAndRecipientCannotHaveSameEmail() {
-        TemplateState state = new TemplateState("Hello-World",alice.getParty(),bob.getParty());
+        TemplateState state = new TemplateState("Hello-World", alice.getParty(), bob.getParty());
         ledger(ledgerServices, l -> {
             l.transaction(tx -> {
                 tx.input(TemplateContract.ID, state);
@@ -40,9 +39,9 @@ public class ContractTests {
 
     //Basket of Apple cordapp testers
     @Test
-    public void StampIssuanceCanOnlyHaveOneOutput(){
-        AppleStamp stamp = new AppleStamp("FUji4072", alice.getParty(),bob.getParty(),new UniqueIdentifier());
-        AppleStamp stamp2 = new AppleStamp("HoneyCrispy7864", alice.getParty(),bob.getParty(),new UniqueIdentifier());
+    public void StampIssuanceCanOnlyHaveOneOutput() {
+        AppleStamp stamp = new AppleStamp("FUji4072", alice.getParty(), bob.getParty(), new UniqueIdentifier());
+        AppleStamp stamp2 = new AppleStamp("HoneyCrispy7864", alice.getParty(), bob.getParty(), new UniqueIdentifier());
 
         ledger(ledgerServices, l -> {
             l.transaction(tx -> {
@@ -61,24 +60,22 @@ public class ContractTests {
     }
 
     @Test
-    public void StampMustHaveDescription(){
-        AppleStamp stamp = new AppleStamp("", alice.getParty(),bob.getParty(),new UniqueIdentifier());
-        AppleStamp stamp2 = new AppleStamp("FUji4072", alice.getParty(),bob.getParty(),new UniqueIdentifier());
+    public void StampMustHaveDescription() {
+        AppleStamp stamp = new AppleStamp("", alice.getParty(), bob.getParty(), new UniqueIdentifier());
+        AppleStamp stamp2 = new AppleStamp("FUji4072", alice.getParty(), bob.getParty(), new UniqueIdentifier());
 
         ledger(ledgerServices, l -> {
             l.transaction(tx -> {
                 tx.output(AppleStampContract.ID, stamp);
-                tx.command(Arrays.asList(alice.getPublicKey(),bob.getPublicKey()), new AppleStampContract.Commands.Issue());
+                tx.command(Arrays.asList(alice.getPublicKey(), bob.getPublicKey()), new AppleStampContract.Commands.Issue());
                 return tx.fails(); //fails because of having inputs
             });
             l.transaction(tx -> {
                 tx.output(AppleStampContract.ID, stamp2);
-                tx.command(Arrays.asList(alice.getPublicKey(),bob.getPublicKey()), new AppleStampContract.Commands.Issue());
+                tx.command(Arrays.asList(alice.getPublicKey(), bob.getPublicKey()), new AppleStampContract.Commands.Issue());
                 return tx.verifies();
             });
             return null;
         });
     }
-
-
 }

--- a/Basic/tutorial-applestamp/contracts/src/test/java/com/tutorial/contracts/StateTests.java
+++ b/Basic/tutorial-applestamp/contracts/src/test/java/com/tutorial/contracts/StateTests.java
@@ -25,5 +25,4 @@ public class StateTests {
         AppleStamp.class.getDeclaredField("holder");
         assert (AppleStamp.class.getDeclaredField("issuer").getType().equals(Party.class));
     }
-
 }

--- a/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/CreateAndIssueAppleStamp.java
+++ b/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/CreateAndIssueAppleStamp.java
@@ -5,24 +5,23 @@ import com.tutorial.contracts.AppleStampContract;
 import com.tutorial.states.AppleStamp;
 import net.corda.core.contracts.UniqueIdentifier;
 import net.corda.core.flows.*;
+import net.corda.core.identity.CordaX500Name;
 import net.corda.core.identity.Party;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.transactions.TransactionBuilder;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import net.corda.core.identity.CordaX500Name;
 
 public class CreateAndIssueAppleStamp {
 
     @InitiatingFlow
     @StartableByRPC
-    public static class CreateAndIssueAppleStampInitiator  extends FlowLogic<SignedTransaction>{
+    public static class CreateAndIssueAppleStampInitiator extends FlowLogic<SignedTransaction> {
 
         private String stampDescription;
         private Party holder;
 
-        public CreateAndIssueAppleStampInitiator(String stampDescription,  Party holder) {
+        public CreateAndIssueAppleStampInitiator(String stampDescription, Party holder) {
             this.stampDescription = stampDescription;
             this.holder = holder;
         }
@@ -37,13 +36,13 @@ public class CreateAndIssueAppleStamp {
 
             //Building the output AppleStamp state
             UniqueIdentifier uniqueID = new UniqueIdentifier();
-            AppleStamp newStamp = new AppleStamp(this.stampDescription,this.getOurIdentity(),this.holder,uniqueID);
+            AppleStamp newStamp = new AppleStamp(this.stampDescription, this.getOurIdentity(), this.holder, uniqueID);
 
             //Compositing the transaction
             TransactionBuilder txBuilder = new TransactionBuilder(notary)
                     .addOutputState(newStamp)
                     .addCommand(new AppleStampContract.Commands.Issue(),
-                            Arrays.asList(getOurIdentity().getOwningKey(),holder.getOwningKey()));
+                            Arrays.asList(getOurIdentity().getOwningKey(), holder.getOwningKey()));
 
             // Verify that the transaction is valid.
             txBuilder.verify(getServiceHub());
@@ -62,7 +61,7 @@ public class CreateAndIssueAppleStamp {
     }
 
     @InitiatedBy(CreateAndIssueAppleStampInitiator.class)
-    public static class CreateAndIssueAppleStampResponder extends FlowLogic<Void>{
+    public static class CreateAndIssueAppleStampResponder extends FlowLogic<Void> {
 
         //private variable
         private FlowSession counterpartySession;
@@ -96,7 +95,6 @@ public class CreateAndIssueAppleStamp {
             return null;
         }
     }
-
 }
 
 //flow start CreateAndIssueAppleStampInitiator stampDescription: Fuji0472, holder: Peter

--- a/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/PackageApples.java
+++ b/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/PackageApples.java
@@ -4,12 +4,12 @@ import co.paralleluniverse.fibers.Suspendable;
 import com.tutorial.contracts.BasketOfApplesContract;
 import com.tutorial.states.BasketOfApples;
 import net.corda.core.flows.*;
+import net.corda.core.identity.CordaX500Name;
 import net.corda.core.identity.Party;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.transactions.TransactionBuilder;
 
 import java.util.Collections;
-import net.corda.core.identity.CordaX500Name;
 
 public class PackageApples {
 
@@ -34,7 +34,7 @@ public class PackageApples {
             final Party notary = getServiceHub().getNetworkMapCache().getNotary(CordaX500Name.parse("O=Notary,L=London,C=GB"));
 
             //Create the output object
-            BasketOfApples basket = new BasketOfApples(this.appleDescription,this.getOurIdentity(),this.weight);
+            BasketOfApples basket = new BasketOfApples(this.appleDescription, this.getOurIdentity(), this.weight);
 
             //Building transaction
             TransactionBuilder txBuilder = new TransactionBuilder(notary)
@@ -51,7 +51,6 @@ public class PackageApples {
             return subFlow(new FinalityFlow(signedTransaction, Collections.emptyList()));
         }
     }
-
 }
 
 //flow start PackApplesInitiator appleDescription: Fuji4072, weight: 10

--- a/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/RedeemApples.java
+++ b/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/RedeemApples.java
@@ -1,7 +1,6 @@
 package com.tutorial.flows;
 
 import co.paralleluniverse.fibers.Suspendable;
-import com.tutorial.contracts.AppleStampContract;
 import com.tutorial.contracts.BasketOfApplesContract;
 import com.tutorial.states.AppleStamp;
 import com.tutorial.states.BasketOfApples;
@@ -21,7 +20,7 @@ public class RedeemApples {
 
     @InitiatingFlow
     @StartableByRPC
-    public static class RedeemApplesInitiator extends FlowLogic<SignedTransaction>{
+    public static class RedeemApplesInitiator extends FlowLogic<SignedTransaction> {
 
         private Party buyer;
         private UniqueIdentifier stampId;
@@ -61,7 +60,7 @@ public class RedeemApples {
                     .addInputState(BasketOfApplesStateAndRef)
                     .addOutputState(output, BasketOfApplesContract.ID)
                     .addCommand(new BasketOfApplesContract.Commands.Redeem(),
-                            Arrays.asList(getOurIdentity().getOwningKey(),this.buyer.getOwningKey()));
+                            Arrays.asList(getOurIdentity().getOwningKey(), this.buyer.getOwningKey()));
 
             // Verify that the transaction is valid.
             txBuilder.verify(getServiceHub());
@@ -82,7 +81,7 @@ public class RedeemApples {
     }
 
     @InitiatedBy(RedeemApplesInitiator.class)
-    public static class RedeemApplesResponder extends FlowLogic<Void>{
+    public static class RedeemApplesResponder extends FlowLogic<Void> {
         //private variable
         private FlowSession counterpartySession;
 
@@ -104,6 +103,5 @@ public class RedeemApples {
             return null;
         }
     }
-
 }
 //flow start RedeemApplesInitiator buyer: Peter, stampId:

--- a/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/TemplateInitiator.java
+++ b/Basic/tutorial-applestamp/workflows/src/main/java/com/tutorial/flows/TemplateInitiator.java
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable;
 import com.tutorial.contracts.TemplateContract;
 import com.tutorial.states.TemplateState;
 import net.corda.core.flows.*;
+import net.corda.core.identity.CordaX500Name;
 import net.corda.core.identity.Party;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.transactions.TransactionBuilder;
@@ -12,7 +13,6 @@ import net.corda.core.utilities.ProgressTracker;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import net.corda.core.identity.CordaX500Name;
 
 // ******************
 // * TemplateInitiator flow *
@@ -23,17 +23,18 @@ public class TemplateInitiator extends FlowLogic<SignedTransaction> {
 
     // We will not use these ProgressTracker for this Hello-World sample
     private final ProgressTracker progressTracker = new ProgressTracker();
+
     @Override
     public ProgressTracker getProgressTracker() {
         return progressTracker;
     }
 
     //private variables
-    private Party sender ;
+    private Party sender;
     private Party receiver;
 
     //public constructor
-    public TemplateInitiator(Party sendTo){
+    public TemplateInitiator(Party sendTo) {
         this.receiver = sendTo;
     }
 
@@ -50,14 +51,14 @@ public class TemplateInitiator extends FlowLogic<SignedTransaction> {
         final Party notary = getServiceHub().getNetworkMapCache().getNotary(CordaX500Name.parse("O=Notary,L=London,C=GB"));
 
         //Compose the State that carries the Hello World message
-        final TemplateState output = new TemplateState(msg,sender,receiver);
+        final TemplateState output = new TemplateState(msg, sender, receiver);
 
         // Step 3. Create a new TransactionBuilder object.
         final TransactionBuilder builder = new TransactionBuilder(notary);
 
         // Step 4. Add the iou as an output state, as well as a command to the transaction builder.
         builder.addOutputState(output);
-        builder.addCommand(new TemplateContract.Commands.Send(), Arrays.asList(this.sender.getOwningKey(),this.receiver.getOwningKey()) );
+        builder.addCommand(new TemplateContract.Commands.Send(), Arrays.asList(this.sender.getOwningKey(), this.receiver.getOwningKey()));
 
 
         // Step 5. Verify and sign it with our KeyPair.
@@ -66,7 +67,7 @@ public class TemplateInitiator extends FlowLogic<SignedTransaction> {
 
 
         // Step 6. Collect the other party's signature using the SignTransactionFlow.
-        List<Party> otherParties = output.getParticipants().stream().map(el -> (Party)el).collect(Collectors.toList());
+        List<Party> otherParties = output.getParticipants().stream().map(el -> (Party) el).collect(Collectors.toList());
         otherParties.remove(getOurIdentity());
         List<FlowSession> sessions = otherParties.stream().map(el -> initiateFlow(el)).collect(Collectors.toList());
 

--- a/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/CreateAndIssueAppleStampTest.java
+++ b/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/CreateAndIssueAppleStampTest.java
@@ -24,8 +24,8 @@ public class CreateAndIssueAppleStampTest {
     @Before
     public void setup() {
         network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows")))
+                        TestCordapp.findCordapp("com.tutorial.contracts"),
+                        TestCordapp.findCordapp("com.tutorial.flows")))
                 .withNotarySpecs(ImmutableList.of(new MockNetworkNotarySpec(CordaX500Name.parse("O=Notary,L=London,C=GB"))))
         );
         a = network.createPartyNode(null);
@@ -47,14 +47,14 @@ public class CreateAndIssueAppleStampTest {
         //successful query means the state is stored at node b's vault. Flow went through.
         QueryCriteria inputCriteria = new QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.UNCONSUMED);
         TemplateState state = b.getServices().getVaultService()
-                .queryBy(TemplateState.class,inputCriteria).getStates().get(0).getState().getData();
+                .queryBy(TemplateState.class, inputCriteria).getStates().get(0).getState().getData();
     }
 
     @Test
-    public void CreateAndIssueAppleStampTest(){
+    public void CreateAndIssueAppleStampTest() {
         CreateAndIssueAppleStamp.CreateAndIssueAppleStampInitiator flow1 =
                 new CreateAndIssueAppleStamp.CreateAndIssueAppleStampInitiator(
-                        "HoneyCrispy 4072",this.b.getInfo().getLegalIdentities().get(0));
+                        "HoneyCrispy 4072", this.b.getInfo().getLegalIdentities().get(0));
         Future<SignedTransaction> future1 = a.startFlow(flow1);
         network.runNetwork();
 
@@ -62,11 +62,7 @@ public class CreateAndIssueAppleStampTest {
         QueryCriteria inputCriteria = new QueryCriteria.VaultQueryCriteria()
                 .withStatus(Vault.StateStatus.UNCONSUMED);
         AppleStamp state = b.getServices().getVaultService()
-                .queryBy(AppleStamp.class,inputCriteria).getStates().get(0).getState().getData();
-        assert(state.getStampDesc().equals("HoneyCrispy 4072"));
+                .queryBy(AppleStamp.class, inputCriteria).getStates().get(0).getState().getData();
+        assert (state.getStampDesc().equals("HoneyCrispy 4072"));
     }
-
-
-
-
 }

--- a/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/FarmerSelfCreateBasketOfApplesTest.java
+++ b/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/FarmerSelfCreateBasketOfApplesTest.java
@@ -22,8 +22,8 @@ public class FarmerSelfCreateBasketOfApplesTest {
     @Before
     public void setup() {
         network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows")))
+                        TestCordapp.findCordapp("com.tutorial.contracts"),
+                        TestCordapp.findCordapp("com.tutorial.flows")))
                 .withNotarySpecs(ImmutableList.of(new MockNetworkNotarySpec(CordaX500Name.parse("O=Notary,L=London,C=GB")))));
         a = network.createPartyNode(null);
         b = network.createPartyNode(null);
@@ -36,7 +36,7 @@ public class FarmerSelfCreateBasketOfApplesTest {
     }
 
     @Test
-    public void createBasketOfApples(){
+    public void createBasketOfApples() {
         PackageApples.PackApplesInitiator flow1 = new PackageApples.PackApplesInitiator("Fuji4072", 10);
         Future<SignedTransaction> future = a.startFlow(flow1);
         network.runNetwork();
@@ -44,13 +44,13 @@ public class FarmerSelfCreateBasketOfApplesTest {
         //successful query means the state is stored at node b's vault. Flow went through.
         QueryCriteria inputCriteria = new QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.UNCONSUMED);
         BasketOfApples state = a.getServices().getVaultService()
-                .queryBy(BasketOfApples.class,inputCriteria).getStates().get(0).getState().getData();
+                .queryBy(BasketOfApples.class, inputCriteria).getStates().get(0).getState().getData();
 
         System.out.println("-------------------------");
         System.out.println(state.getOwner());
         System.out.println("-------------------------");
 
-        assert(state.getDescription().equals("Fuji4072"));
+        assert (state.getDescription().equals("Fuji4072"));
     }
 }
 

--- a/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/FlowTests.java
+++ b/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/FlowTests.java
@@ -22,8 +22,8 @@ public class FlowTests {
     @Before
     public void setup() {
         network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows")))
+                        TestCordapp.findCordapp("com.tutorial.contracts"),
+                        TestCordapp.findCordapp("com.tutorial.flows")))
                 .withNotarySpecs(ImmutableList.of(new MockNetworkNotarySpec(CordaX500Name.parse("O=Notary,L=London,C=GB"))))
         );
         a = network.createPartyNode(null);
@@ -45,6 +45,6 @@ public class FlowTests {
         //successful query means the state is stored at node b's vault. Flow went through.
         QueryCriteria inputCriteria = new QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.UNCONSUMED);
         TemplateState state = b.getServices().getVaultService()
-                .queryBy(TemplateState.class,inputCriteria).getStates().get(0).getState().getData();
+                .queryBy(TemplateState.class, inputCriteria).getStates().get(0).getState().getData();
     }
 }

--- a/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/RedeemApplesWithStampTest.java
+++ b/Basic/tutorial-applestamp/workflows/src/test/java/com/tutorial/RedeemApplesWithStampTest.java
@@ -27,8 +27,8 @@ public class RedeemApplesWithStampTest {
     @Before
     public void setup() {
         network = new MockNetwork(new MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows")))
+                        TestCordapp.findCordapp("com.tutorial.contracts"),
+                        TestCordapp.findCordapp("com.tutorial.flows")))
                 .withNotarySpecs(ImmutableList.of(new MockNetworkNotarySpec(CordaX500Name.parse("O=Notary,L=London,C=GB"))))
         );
         a = network.createPartyNode(null);
@@ -51,7 +51,7 @@ public class RedeemApplesWithStampTest {
         //Issue Apple Stamp
         CreateAndIssueAppleStamp.CreateAndIssueAppleStampInitiator issueAppleStamp =
                 new CreateAndIssueAppleStamp.CreateAndIssueAppleStampInitiator(
-                        "Fuji4072",this.b.getInfo().getLegalIdentities().get(0));
+                        "Fuji4072", this.b.getInfo().getLegalIdentities().get(0));
         Future<SignedTransaction> future1 = a.startFlow(issueAppleStamp);
         network.runNetwork();
 
@@ -59,7 +59,7 @@ public class RedeemApplesWithStampTest {
         UniqueIdentifier id = issuedStamp.getLinearId();
 
         //Redeem Basket of Apples with stamp
-        RedeemApples.RedeemApplesInitiator redeemApples = new RedeemApples.RedeemApplesInitiator(b.getInfo().getLegalIdentities().get(0),id);
+        RedeemApples.RedeemApplesInitiator redeemApples = new RedeemApples.RedeemApplesInitiator(b.getInfo().getLegalIdentities().get(0), id);
         Future<SignedTransaction> future2 = a.startFlow(redeemApples);
         network.runNetwork();
 
@@ -68,6 +68,6 @@ public class RedeemApplesWithStampTest {
         BasketOfApples state = b.getServices().getVaultService()
                 .queryBy(BasketOfApples.class, outputCriteria).getStates().get(0).getState().getData();
 
-        assert(state.getDescription().equals("Fuji4072"));
+        assert (state.getDescription().equals("Fuji4072"));
     }
 }


### PR DESCRIPTION
### Overview / Changes
Removed unused imports and applied formatting to `tutorial-applestamp` **Java** sample project. 

This clean-up is done as part of improving Corda 4.9 tutorial document and its scope is limited to `tutorial-applestamp`.

Note: Intellij auto-formatting feature (both for imports and logic) is used. Though it doesn't always provide the best formatting, in most cases it gives a better and consistent formatting. 

### Test 
No logic change. Ran `./gradlew build` and verified it succeeded.