### PR TITLE
Fixes class not found when running gradlew.bat runTestClient

### DIFF
--- a/Basic/cordapp-example/clients/build.gradle
+++ b/Basic/cordapp-example/clients/build.gradle
@@ -34,7 +34,7 @@ springBoot {
  */
 task runTestClient(type: JavaExec, dependsOn: assemble) {
     classpath = sourceSets.main.runtimeClasspath
-    main = 'net.corda.samples.example.webserver.Client'
+    main = 'net.corda.samples.example.Client'
     args 'localhost:10006', 'user1', 'test'
 }
 


### PR DESCRIPTION
Before: Error: Could not find or load main class net.corda.samples.example.webserver.Client

After: -- Here is the networkMap snapshot -- // -- Here is the node info of the node that the client connected to -- // with the relevant information about the nodes