### PR TITLE
ENT-11849: Fix date formatting issue in auction-cordapp

### DIFF
--- a/Advanced/auction-cordapp/README.md
+++ b/Advanced/auction-cordapp/README.md
@@ -111,7 +111,7 @@ available in the `Active Auction` section.
 
 5. Place one more bid by switching to PartyC.
 
-6. What for the auction to end.
+6. Wait for the auction to end.
 
 7. Once the auction is ended its ready to be settled. Settlement can be initiated by the
 highest bidder. Considering PartyC is the highest bidder, switch to PartyC.

--- a/Advanced/auction-cordapp/client/src/main/java/net/corda/samples/auction/client/Controller.java
+++ b/Advanced/auction-cordapp/client/src/main/java/net/corda/samples/auction/client/Controller.java
@@ -14,8 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.*;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -71,11 +72,12 @@ public class Controller {
     @PostMapping("create")
     public APIResponse<Void> createAuction(@RequestBody Forms.CreateAuctionForm auctionForm){
         try {
+            SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy hh:mm:ss a");
+            LocalDateTime formattedDeadline = LocalDateTime.ofInstant(dateFormatter.parse(auctionForm.getDeadline()).toInstant(), ZoneId.systemDefault());
             activeParty.startFlowDynamic(CreateAuctionFlow.CreateAuctionInitiator.class,
                     Amount.parseCurrency(auctionForm.getBasePrice() + " USD"),
                     UUID.fromString(auctionForm.getAssetId()),
-                    LocalDateTime.parse(auctionForm.getDeadline(),
-                            DateTimeFormatter.ofPattern("dd-MM-yyyy hh:mm:ss a"))).getReturnValue().get();
+                    formattedDeadline).getReturnValue().get();
             return APIResponse.success();
         }catch (ExecutionException e){
             if(e.getCause() != null && e.getCause().getClass().equals(TransactionVerificationException.ContractRejection.class)){


### PR DESCRIPTION
Fix an issue with date formatting: `Text '17-05-2024 03:49:32 PM' could not be parsed at index 20.`.
The String date was not transformed by `DateTimeFormatter` correctly.
More info under [ENT-11849](https://r3-cev.atlassian.net/browse/ENT-11849)

Now all steps from CorDapp's README work correctly.

[ENT-11849]: https://r3-cev.atlassian.net/browse/ENT-11849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ