### PR TITLE
ENT-14290: Implement SNAPSHOT dependency: referenceStates-sanctionsBody

### DIFF
--- a/Features/referencestates-sanctionsbody/build.gradle
+++ b/Features/referencestates-sanctionsbody/build.gradle
@@ -50,6 +50,9 @@ allprojects { //Properties that you need to compile your project (The applicatio
         maven { url 'https://download.corda.net/maven/corda-dependencies' }
         maven { url 'https://download.corda.net/maven/corda-releases' }
         maven { url 'https://jitpack.io' }
+
+        maven { url 'https://download.corda.net/maven/corda-dev' }
+        maven { url 'https://download.corda.net/maven/r3-corda-dev' }
     }
 
     java {


### PR DESCRIPTION
ENT 4.12-SNAPSHOT: [ReferenceStatesSanctionBodyTests](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/2576/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/)
ENT 4.13-SNAPSHOT: [ReferenceStatesSanctionBodyTests](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/2577/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/)
ENT 4.12.7 [ReferenceStatesSanctionBodyTests](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/2578/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/)
ENT 4.13-RC01 [ReferenceStatesSanctionBodyTests](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/2580/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/)

>Add corda maven dependencies in order to  run  `referencestates-sanctionsBody` cordapp on `SNAPSHOT` version